### PR TITLE
Accounted for KSLabel repeat

### DIFF
--- a/spikeinterface/extractors/phykilosortextractors.py
+++ b/spikeinterface/extractors/phykilosortextractors.py
@@ -71,7 +71,7 @@ class BasePhyKilosortSortingExtractor(BaseSorting):
                 if cluster_info is None:
                     cluster_info = new_property
                 else:
-                    cluster_info = pd.merge(cluster_info, new_property, on='cluster_id')
+                    cluster_info = pd.merge(cluster_info, new_property, on='cluster_id',suffixes=[None,'_repeat'])
 
         # in case no tsv/csv files are found populate cluster info with minimal info
         if cluster_info is None:


### PR DESCRIPTION
Sometimes there are multiple Kilosort files with the column "KSLabel". I think this is before the user has manually assigned groups, and they are identical. In this case, one needs to be named 'KSLabel' in the extracted DataFrame, rather than naming them 'KSLabel_x' and _y, or the keep_good_only logic won't work.